### PR TITLE
Dedup, interval, and degF rounding fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ const sensor = new Sensor({
 	// If omitted, a Barnowl instance will be created and register the BarnowlHci listener
 	// Use this if you already have a Barnowl instance in your project and you just want to
 	// add the ability to process Omron data frames.
-	barnowl: existingBarnowlInstance
+    barnowl: existingBarnowlInstance,
+    
+    // Minimum number of seconds to wait before emitting another reading.
+    interval: 5
 
 });
 ```


### PR DESCRIPTION
Added these features

1. Do not send duplicate messages (of same type with same sequence ID)
2. Add a configuration option to create a minimum event interval

Added these fixes

1. Degrees F conversion rounds to 2 decimal places